### PR TITLE
MM-24294: Check the type before assigning a value to a slice (#157)

### DIFF
--- a/commands/config.go
+++ b/commands/config.go
@@ -42,7 +42,7 @@ var ConfigSetCmd = &cobra.Command{
 	Use:     "set",
 	Short:   "Set config setting",
 	Long:    "Sets the value of a config setting by its name in dot notation. Accepts multiple values for array settings",
-	Example: "config set SqlSettings.DriverName mysql",
+	Example: "config set SqlSettings.DriverName mysql\nconfig set SqlSettings.DataSourceReplicas \"replica1\" \"replica2\"",
 	Args:    cobra.MinimumNArgs(2),
 	RunE:    withClient(configSetCmdF),
 }
@@ -140,7 +140,11 @@ func setValueWithConversion(val reflect.Value, newValue interface{}) error {
 		if val.Type().Elem().Kind() != reflect.String {
 			return errors.New("unsupported type of slice")
 		}
-		val.Set(reflect.ValueOf(newValue))
+		v := reflect.ValueOf(newValue)
+		if v.Kind() != reflect.Slice {
+			return errors.New("target value is of type Array and provided value is not")
+		}
+		val.Set(v)
 		return nil
 	case reflect.Int:
 		v, err := strconv.ParseInt(newValue.(string), 10, 64)

--- a/commands/config_test.go
+++ b/commands/config_test.go
@@ -346,6 +346,26 @@ func (s *MmctlUnitTestSuite) TestConfigSetCmd() {
 		s.Require().Len(printer.GetErrorLines(), 0)
 	})
 
+	s.Run("Should get an error if a string is passed while trying to set a slice", func() {
+		printer.Clean()
+		args := []string{"SqlSettings.DataSourceReplicas", "[\"test1\", \"test2\"]"}
+		defaultConfig := &model.Config{}
+		defaultConfig.SetDefaults()
+		inputConfig := &model.Config{}
+		inputConfig.SetDefaults()
+		inputConfig.SqlSettings.DataSourceReplicas = []string{"test1", "test2"}
+
+		s.client.
+			EXPECT().
+			GetConfig().
+			Return(defaultConfig, &model.Response{Error: nil}).
+			Times(1)
+
+		err := configSetCmdF(s.client, &cobra.Command{}, args)
+		s.Require().NotNil(err)
+		s.Require().Len(printer.GetLines(), 0)
+	})
+
 	s.Run("Get error if the key doesn't exists", func() {
 		printer.Clean()
 		defaultConfig := &model.Config{}

--- a/docs/mmctl_config_set.rst
+++ b/docs/mmctl_config_set.rst
@@ -21,6 +21,7 @@ Examples
 ::
 
   config set SqlSettings.DriverName mysql
+  config set SqlSettings.DataSourceReplicas "replica1" "replica2"
 
 Options
 ~~~~~~~


### PR DESCRIPTION
* MM-24294: Check the type before assigning a value to a slice

(reflect.Value).Set was being called without checking whether the input
value's type was indeed a slice or not. This would cause a panic in case
when the user is unsure of how to enter an array value to set a config key.

To prevent this, we check for the type and raise an appropriate error
and also add an example to show how to set an array value.

* Updated docs